### PR TITLE
Exception on label function returning unsupported type

### DIFF
--- a/dff/script/core/normalization.py
+++ b/dff/script/core/normalization.py
@@ -12,7 +12,7 @@ from typing import Union, Callable, Optional, TYPE_CHECKING
 
 from .keywords import Keywords
 from .context import Context
-from .types import NodeLabel1Type, NodeLabel2Type, NodeLabel3Type, NodeLabelType, ConditionType, LabelType
+from .types import NodeLabel3Type, NodeLabelType, ConditionType, LabelType
 from .message import Message
 
 if TYPE_CHECKING:

--- a/dff/script/core/normalization.py
+++ b/dff/script/core/normalization.py
@@ -12,7 +12,7 @@ from typing import Union, Callable, Optional, TYPE_CHECKING
 
 from .keywords import Keywords
 from .context import Context
-from .types import NodeLabel3Type, NodeLabelType, ConditionType, LabelType
+from .types import NodeLabel1Type, NodeLabel2Type, NodeLabel3Type, NodeLabelType, ConditionType, LabelType
 from .message import Message
 
 if TYPE_CHECKING:
@@ -34,6 +34,16 @@ def normalize_label(
     :return: Result of the label normalization,
         if Callable is returned, the normalized result is returned.
     """
+
+    if not (
+        callable(label)
+        or (isinstance(label, str) or isinstance(label, Keywords))
+        or (isinstance(label, tuple) and len(label) == 2 and isinstance(label[-1], float))
+        or (isinstance(label, tuple) and len(label) == 2 and isinstance(label[-1], str))
+        or (isinstance(label, tuple) and len(label) == 3)
+    ):
+        raise TypeError("Label function returned type:", type(label), "which is not supported.")
+
     if callable(label):
 
         def get_label_handler(ctx: Context, pipeline: Pipeline) -> NodeLabel3Type:

--- a/tests/script/core/test_normalization.py
+++ b/tests/script/core/test_normalization.py
@@ -53,6 +53,19 @@ def test_normalize_label():
     assert normalize_label(("flow", "node", 1.0), "flow") == ("flow", "node", 1.0)
     assert normalize_label(("node", 1.0), "flow") == ("flow", "node", 1.0)
 
+    def wrong_label_type_test(label) -> bool:
+        try:
+            normalize_label(label, "flow")
+            return False
+        except TypeError:
+            return True
+
+    assert wrong_label_type_test(None)
+    assert wrong_label_type_test(True)
+    assert wrong_label_type_test(0.7)
+    assert not wrong_label_type_test("node")
+    assert not wrong_label_type_test(("node", 1.0))
+
 
 def test_normalize_condition():
     ctx, actor = create_env()


### PR DESCRIPTION
# Description

- Added checking label type to normalize_label() and raising an exception in case a label's type is wrong. All internal functions use normalized label types, so this catches any wrong inputs from the user.
- Relevant unit-tests added
# Checklist

- [x] I have performed a self-review of the changes

# To Consider
- Check if new tests are good enough.
- Should NoneType be processed separately? The message could slightly vary and be easier for newer users, but it seems direct enough already.
- That long "if" statement could be done better with something like a "supported_types" list, but it creates issues with 'typing' types. Another option is placing it all into a separate function so as not to bloat the syntax, but it just feels wrong there.