### PR TITLE
`pepy` badge fix

### DIFF
--- a/.github/process_github_events.py
+++ b/.github/process_github_events.py
@@ -48,6 +48,7 @@ Here's a release checklist:
 - [ ] Update package version
 - [ ] Update `poetry.lock`
 - [ ] Change PR merge option
+- [ ] Update template repo
 - [ ] Search for objects to be deprecated
 """
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/deeppavlov/chatsky/blob/master/LICENSE)
 ![Python 3.8, 3.9, 3.10, 3.11](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-green.svg)
 [![PyPI](https://img.shields.io/pypi/v/chatsky)](https://pypi.org/project/chatsky/)
-[![Downloads](https://pepy.tech/badge/chatsky)](https://pepy.tech/project/chatsky)
+[![Downloads](https://static.pepy.tech/badge/chatsky)](https://pepy.tech/project/chatsky)
 
 Chatsky allows you to develop conversational services.
 Chatsky offers a specialized domain-specific language (DSL) for quickly writing dialogs in pure Python. The service is created by defining a special dialog graph that determines the behavior of the dialog agent. The latter is then leveraged in the Chatsky pipeline.


### PR DESCRIPTION
# Description

Pepy markdown badge was outdated. Now it is updated once again.

# Checklist

- [x] I have performed a self-review of the changes