### PR TITLE
freeze poetry version in workflows

### DIFF
--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: setup poetry and install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
           python -m poetry install --with tutorials,docs --all-extras --no-ansi --no-interaction
 
       - name: build documentation

--- a/.github/workflows/build_and_upload_release.yml
+++ b/.github/workflows/build_and_upload_release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: setup poetry
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
 
       - name: build wheels and test uploading to pypi
         if: startsWith(github.ref, 'refs/tags/v') != true

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: setup poetry and install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
           python -m poetry install --with lint --no-ansi --no-interaction
 
       - name: run codestyle

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: setup poetry and install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
           python -m poetry install --with test,tutorials --all-extras --no-ansi --no-interaction
 
       - name: run tests

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
           python -m poetry install --with test,tutorials --all-extras --no-ansi --no-interaction
 
       - name: run pytest
@@ -56,7 +56,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip poetry==1.8.5
           python -m poetry install --with test --no-ansi --no-interaction
 
       - name: run pytest


### PR DESCRIPTION
# Description

Fix poetry version to 1.8.5.
v2.0 release breaks workflows.

# Checklist

- [x] I have performed a self-review of the changes